### PR TITLE
0.5.0/DesignPepsiLogo

### DIFF
--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -1,6 +1,7 @@
 import APPLE_COORDINATES from './maps/apple';
 import TWITTER_COORDINATES from './maps/twitter';
 import ADOBE_COORDINATES from './maps/adobe';
+import PEPSI_COORDINATES from './maps/pepsi';
 
 export default {
   apple: {
@@ -14,5 +15,9 @@ export default {
   adobe: {
     id: 'adobe',
     coordinates: ADOBE_COORDINATES,
+  },
+  pepsi: {
+    id: 'pepsi',
+    coordinates: PEPSI_COORDINATES,
   },
 };

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -5,4 +5,5 @@ import CONFIG from './config';
 const Apple = Factory.create(CONFIG.apple);
 const Twitter = Factory.create(CONFIG.twitter);
 const Adobe = Factory.create(CONFIG.adobe);
+const Pepsi = Factory.create(CONFIG.pepsi);
 /* eslint-enable no-unused-vars */

--- a/app/scripts/maps/pepsi.js
+++ b/app/scripts/maps/pepsi.js
@@ -1,0 +1,3392 @@
+export default [
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 1
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 2
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 3
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 4
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 5
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 6
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 7
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 8
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: false,
+  }, // 9
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: false,
+  }, // 10
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  }, // 11
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  }, // 12
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  }, // 13
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  }, // 14
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  }, // 15
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  }, // 16
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  }, // 17
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  }, // 18
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  }, // 19
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  }, // 20
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  }, // 21
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: false,
+  }, // 22
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: false,
+  }, // 23
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: true,
+    fill: 'red',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 24
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 25
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 26
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 27
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 28
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 29
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 30
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: true,
+    fill: 'blue',
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 31
+];

--- a/app/styles/components/_pepsi.scss
+++ b/app/styles/components/_pepsi.scss
@@ -1,0 +1,15 @@
+@charset 'utf-8';
+
+[id='pepsi'] {
+  width: calc(6px * 30);
+
+  .point {
+    &.red {
+      background-color: palette(red); // sass-lint:disable-line no-color-literals, no-color-keywords
+    }
+
+    &.blue {
+      background-color: palette(blue); // sass-lint:disable-line no-color-literals, no-color-keywords
+    }
+  }
+}

--- a/app/styles/index.scss
+++ b/app/styles/index.scss
@@ -12,3 +12,4 @@
 @import './components/apple';
 @import './components/twitter';
 @import './components/adobe';
+@import './components/pepsi';

--- a/app/styles/theme/_palette.scss
+++ b/app/styles/theme/_palette.scss
@@ -1,6 +1,7 @@
 @charset 'utf-8';
 
 $palette: (
+  blue:               #00F, // sass-lint:disable-line no-color-keywords
   dodger-blue:        #1DA1F2,
   red:                #F00 // sass-lint:disable-line no-color-keywords
 );

--- a/tests/spec/config.pepsi.spec.js
+++ b/tests/spec/config.pepsi.spec.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import CONFIG from '../../app/scripts/config';
+
+describe('Pepsi Configuration :: Object', () => {
+  it('should have any keys of pepsi', () => {
+    expect(CONFIG).to.have.any.keys('pepsi');
+  });
+
+  it('should Pepsi have an id property', () => {
+    expect(CONFIG.pepsi).to.have.property('id');
+  });
+
+  it('should Pepsi have a coordinates property', () => {
+    expect(CONFIG.pepsi).to.have.property('coordinates');
+  });
+
+  it('should id property be a string', () => {
+    expect(CONFIG.pepsi.id).to.be.a('string');
+  });
+
+  it('should coordinates property be an instace of Array', () => {
+    expect(CONFIG.pepsi.coordinates).to.be.an('Array');
+  });
+
+  it('should have all id, coordinates keys', () => {
+    expect(CONFIG.pepsi).to.contain.all.keys('id', 'coordinates');
+  });
+});

--- a/tests/spec/pepsi.map.spec.js
+++ b/tests/spec/pepsi.map.spec.js
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import coordinates from '../../app/scripts/maps/pepsi';
+
+describe('Coordinates :: Pepsi', () => {
+  it('should be an instance of Array', () => {
+    expect(coordinates).to.be.an.instanceof(Array);
+  });
+
+  it('should have any keys of colour', () => {
+    expect(coordinates[0]).to.have.any.keys('colour');
+  });
+
+  it('should exists', () => {
+    expect(coordinates).to.exist; // eslint-disable-line no-unused-expressions
+  });
+
+  it('should be OK', () => {
+    expect(coordinates).to.be.ok; // eslint-disable-line no-unused-expressions
+  });
+
+  it('should be not null', () => {
+    expect(coordinates).to.not.be.a('null');
+  });
+
+  it('should not be empty', () => {
+    expect(coordinates).to.not.be.an('empty');
+  });
+
+  it('should not be undefined', () => {
+    expect(coordinates).to.not.be.an('undefined');
+  });
+
+  it('should have a colour property', () => {
+    expect(coordinates[0]).to.have.property('colour');
+  });
+
+  it('should have a fill property', () => {
+    expect(coordinates).to.have.property('fill');
+  });
+
+  it('should colour property be a boolean', () => {
+    expect(coordinates[0].colour).to.be.a('boolean');
+  });
+
+  it('should fill property be a string', () => {
+    expect(coordinates[12]).to.have.property('fill').that.is.a('string');
+  });
+
+  it('should have the correct length', () => {
+    expect(coordinates).to.have.lengthOf(coordinates.length);
+  });
+});


### PR DESCRIPTION
Add Pepsi Logo Component in dots.

---

### Issues Addressed

- [x] [#5 – Design Pepsi Logo](https://github.com/yairodriguez/dotbrands/issues/5)

All issues in projects: [dotbrands](https://github.com/yairodriguez/dotbrands/issues)

---

### Release Checklist

- [x] [[`cdfbfd9`]](https://github.com/yairodriguez/dotbrands/commit/cdfbfd9f95dcaf2d72453cc5e1aaef0c47e25eec) -  **maps:** Add Complete Pepsi Object with coordinates.
- [x] [[`df56014`]](https://github.com/yairodriguez/dotbrands/commit/df560141ca4bc5e6533216728d6a3e11dbc79131) - **comp:** Use Factory to create Pepsi logo.
- [x] [[`6eb072f`]](https://github.com/yairodriguez/dotbrands/commit/6eb072fee884f15e493a43433d1212d47c8fcf76) - **style:** Add the correct Pepsi Logo styles.

---

### Approvals

- [x] Final approval @yairodriguez