### PR TITLE
0.7.0/DesignMcDonaldsLogo

### DIFF
--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -3,6 +3,7 @@ import TWITTER_COORDINATES from './maps/twitter';
 import ADOBE_COORDINATES from './maps/adobe';
 import PEPSI_COORDINATES from './maps/pepsi';
 import MASTERCARD_COORDINATES from './maps/mastercard';
+import MCDONALDS_COORDINATES from './maps/mcdonalds';
 
 export default {
   apple: {
@@ -24,5 +25,9 @@ export default {
   mastercard: {
     id: 'mastercard',
     coordinates: MASTERCARD_COORDINATES,
+  },
+  mcdonalds: {
+    id: 'mcdonalds',
+    coordinates: MCDONALDS_COORDINATES,
   },
 };

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -7,4 +7,5 @@ const Twitter = Factory.create(CONFIG.twitter);
 const Adobe = Factory.create(CONFIG.adobe);
 const Pepsi = Factory.create(CONFIG.pepsi);
 const MasterCard = Factory.create(CONFIG.mastercard);
+const McDonalds = Factory.create(CONFIG.mcdonalds);
 /* eslint-enable no-unused-vars */

--- a/app/scripts/maps/mcdonalds.js
+++ b/app/scripts/maps/mcdonalds.js
@@ -1,0 +1,4202 @@
+export default [
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 1
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 2
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 3
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 4
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 5
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 6
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 7
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 8
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 9
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 10
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 11
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 12
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 13
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 14
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 15
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 16
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 17
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  }, // 18
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  }, // 19
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  }, // 20
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  }, // 21
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  }, // 22
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  }, // 23
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  }, // 24
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  }, // 25
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 26
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 27
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 28
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 29
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 30
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 31
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 32
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 33
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 34
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 35
+];

--- a/app/styles/components/_mcdonalds.scss
+++ b/app/styles/components/_mcdonalds.scss
@@ -1,0 +1,11 @@
+@charset 'utf-8';
+
+[id='mcdonalds'] {
+  width: calc(6px * 40);
+
+  .point {
+    &.active {
+      background-color: palette(gold); // sass-lint:disable-line no-color-literals, no-color-keywords
+    }
+  }
+}

--- a/app/styles/components/_section.scss
+++ b/app/styles/components/_section.scss
@@ -8,7 +8,8 @@
     background-color: black(0.95);
   }
 
-  &--adobe {
+  &--adobe,
+  &--mcdonalds {
     background-color: palette(red); // sass-lint:disable-line no-color-keywords, no-color-literals
   }
 }

--- a/app/styles/index.scss
+++ b/app/styles/index.scss
@@ -14,3 +14,4 @@
 @import './components/adobe';
 @import './components/pepsi';
 @import './components/mastercard';
+@import './components/mcdonalds';

--- a/app/styles/theme/_palette.scss
+++ b/app/styles/theme/_palette.scss
@@ -5,6 +5,7 @@ $palette: (
   blue:               #00F, // sass-lint:disable-line no-color-keywords
   dodger-blue:        #1DA1F2,
   eboo:               #EB001B,
+  gold:               #FFD600, // sass-lint:disable-line no-color-keywords
   red:                #F00, // sass-lint:disable-line no-color-keywords
   tree-poppy:         #F79E1B
 );

--- a/tests/spec/config.mcdonalds.spec.js
+++ b/tests/spec/config.mcdonalds.spec.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import CONFIG from '../../app/scripts/config';
+
+describe('McDonalds Configuration :: Object', () => {
+  it('should have any keys of apple', () => {
+    expect(CONFIG).to.have.any.keys('mcdonalds');
+  });
+
+  it('should McDonalds have an id property', () => {
+    expect(CONFIG.mcdonalds).to.have.property('id');
+  });
+
+  it('should McDonalds have a coordinates property', () => {
+    expect(CONFIG.mcdonalds).to.have.property('coordinates');
+  });
+
+  it('should id property be a string', () => {
+    expect(CONFIG.mcdonalds.id).to.be.a('string');
+  });
+
+  it('should coordinates property be an instace of Array', () => {
+    expect(CONFIG.mcdonalds.coordinates).to.be.an('Array');
+  });
+
+  it('should have all id, coordinates keys', () => {
+    expect(CONFIG.mcdonalds).to.contain.all.keys('id', 'coordinates');
+  });
+});

--- a/tests/spec/mcdonalds.map.spec.js
+++ b/tests/spec/mcdonalds.map.spec.js
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import coordinates from '../../app/scripts/maps/mcdonalds';
+
+describe('Coordinates :: McDonalds', () => {
+  it('should be an instance of Array', () => {
+    expect(coordinates).to.be.an.instanceof(Array);
+  });
+
+  it('should have any keys of colour', () => {
+    expect(coordinates[0]).to.have.any.keys('colour');
+  });
+
+  it('should exists', () => {
+    expect(coordinates).to.exist; // eslint-disable-line no-unused-expressions
+  });
+
+  it('should be OK', () => {
+    expect(coordinates).to.be.ok; // eslint-disable-line no-unused-expressions
+  });
+
+  it('should be not null', () => {
+    expect(coordinates).to.not.be.a('null');
+  });
+
+  it('should not be empty', () => {
+    expect(coordinates).to.not.be.an('empty');
+  });
+
+  it('should not be undefined', () => {
+    expect(coordinates).to.not.be.an('undefined');
+  });
+
+  it('should have a colour property', () => {
+    expect(coordinates[0]).to.have.property('colour');
+  });
+
+  it('should colour property be a boolean', () => {
+    expect(coordinates[0].colour).to.be.a('boolean');
+  });
+
+  it('should have the correct length', () => {
+    expect(coordinates).to.have.lengthOf(coordinates.length);
+  });
+});


### PR DESCRIPTION
Add MasterCard Logo Component in dots.

---

### Issues Addressed

- [x] [#7 – Design McDonalds Logo](https://github.com/yairodriguez/dotbrands/issues/7)

All issues in projects: [dotbrands](https://github.com/yairodriguez/dotbrands/issues)

---

### Release Checklist

- [x] [[`60430b5`]](https://github.com/yairodriguez/dotbrands/commit/60430b5c262a6a6e440ca1ffcd98fb61cc31c1eb) -  **maps:** Add Complete McDonalds Object with coordinates.
- [x] [[`e58b5db`]](https://github.com/yairodriguez/dotbrands/commit/e58b5dbdde4bfeeb6bd2391fa4689db37a9a392d) - **comp:** Use Factory to create McDonalds logo.
- [x] [[`931441f`]](https://github.com/yairodriguez/dotbrands/commit/931441f18fe2a667132c176427bdce4ad277012e) - **style:** Add the correct McDonalds Logo styles.

---

### Approvals

- [x] Final approval @yairodriguez