### PR TITLE
0.9.0/DesignMitsubishiLogo

### DIFF
--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -5,6 +5,7 @@ import PEPSI_COORDINATES from './maps/pepsi';
 import MASTERCARD_COORDINATES from './maps/mastercard';
 import MCDONALDS_COORDINATES from './maps/mcdonalds';
 import MICROSOFT_COORDINATES from './maps/microsoft';
+import MITSUBISHI_COORDINATES from './maps/mitsubishi';
 
 export default {
   apple: {
@@ -34,5 +35,9 @@ export default {
   microsoft: {
     id: 'microsoft',
     coordinates: MICROSOFT_COORDINATES,
+  },
+  mitsubishi: {
+    id: 'mitsubishi',
+    coordinates: MITSUBISHI_COORDINATES,
   },
 };

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -9,4 +9,5 @@ const Pepsi = Factory.create(CONFIG.pepsi);
 const MasterCard = Factory.create(CONFIG.mastercard);
 const McDonalds = Factory.create(CONFIG.mcdonalds);
 const Microsoft = Factory.create(CONFIG.microsoft);
+const Mitsubishi = Factory.create(CONFIG.mitsubishi);
 /* eslint-enable no-unused-vars */

--- a/app/scripts/maps/mitsubishi.js
+++ b/app/scripts/maps/mitsubishi.js
@@ -1,0 +1,1652 @@
+export default [
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 1
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 2
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 3
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 4
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 5
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 6
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 7
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 8
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 9
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 10
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 11
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 12
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 13
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 14
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 15
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 16
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 17
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 18
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 19
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  }, // 20
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  }, // 21
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 22
+];

--- a/app/styles/components/_mitsubishi.scss
+++ b/app/styles/components/_mitsubishi.scss
@@ -1,0 +1,11 @@
+@charset 'utf-8';
+
+[id='mitsubishi'] {
+  width: calc(6px * 25);
+
+  .point {
+    &.active {
+      background-color: palette(esoo);
+    }
+  }
+}

--- a/app/styles/index.scss
+++ b/app/styles/index.scss
@@ -16,3 +16,4 @@
 @import './components/mastercard';
 @import './components/mcdonalds';
 @import './components/microsoft';
+@import './components/mitsubishi';

--- a/app/styles/theme/_palette.scss
+++ b/app/styles/theme/_palette.scss
@@ -9,6 +9,7 @@ $palette: (
   crimson:            #EB1D39, // sass-lint:disable-line no-color-keywords
   dodger-blue:        #1DA1F2,
   eboo:               #EB001B,
+  esoo:               #E50012,
   flamingo:           #F8682C,
   gold:               #FFD600, // sass-lint:disable-line no-color-keywords
   pistachio:          #91C300,

--- a/tests/spec/config.mitsubishi.spec.js
+++ b/tests/spec/config.mitsubishi.spec.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import CONFIG from '../../app/scripts/config';
+
+describe('Mitsubishi Configuration :: Object', () => {
+  it('should have any keys of mitsubishi', () => {
+    expect(CONFIG).to.have.any.keys('mitsubishi');
+  });
+
+  it('should Mitsubishi have an id property', () => {
+    expect(CONFIG.mitsubishi).to.have.property('id');
+  });
+
+  it('should Mitsubishi have a coordinates property', () => {
+    expect(CONFIG.mitsubishi).to.have.property('coordinates');
+  });
+
+  it('should id property be a string', () => {
+    expect(CONFIG.mitsubishi.id).to.be.a('string');
+  });
+
+  it('should coordinates property be an instace of Array', () => {
+    expect(CONFIG.mitsubishi.coordinates).to.be.an('Array');
+  });
+
+  it('should have all id, coordinates keys', () => {
+    expect(CONFIG.mitsubishi).to.contain.all.keys('id', 'coordinates');
+  });
+});

--- a/tests/spec/mitsubishi.map.spec.js
+++ b/tests/spec/mitsubishi.map.spec.js
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import coordinates from '../../app/scripts/maps/mitsubishi';
+
+describe('Coordinates :: Mitsubishi', () => {
+  it('should be an instance of Array', () => {
+    expect(coordinates).to.be.an.instanceof(Array);
+  });
+
+  it('should have any keys of colour', () => {
+    expect(coordinates[0]).to.have.any.keys('colour');
+  });
+
+  it('should exists', () => {
+    expect(coordinates).to.exist; // eslint-disable-line no-unused-expressions
+  });
+
+  it('should be OK', () => {
+    expect(coordinates).to.be.ok; // eslint-disable-line no-unused-expressions
+  });
+
+  it('should be not null', () => {
+    expect(coordinates).to.not.be.a('null');
+  });
+
+  it('should not be empty', () => {
+    expect(coordinates).to.not.be.an('empty');
+  });
+
+  it('should not be undefined', () => {
+    expect(coordinates).to.not.be.an('undefined');
+  });
+
+  it('should have a colour property', () => {
+    expect(coordinates[0]).to.have.property('colour');
+  });
+
+  it('should colour property be a boolean', () => {
+    expect(coordinates[0].colour).to.be.a('boolean');
+  });
+
+  it('should have the correct length', () => {
+    expect(coordinates).to.have.lengthOf(coordinates.length);
+  });
+});


### PR DESCRIPTION
Add Mitsubishi Logo Component in dots.

---

### Issues Addressed

- [x] [#9 – Design Mitsubishi Logo](https://github.com/yairodriguez/dotbrands/issues/9)

All issues in projects: [dotbrands](https://github.com/yairodriguez/dotbrands/issues)

---

### Release Checklist

- [x] [[`724f5fa`]](https://github.com/yairodriguez/dotbrands/pull/20/commits/724f5fa7bf6dcafbb52efaf50c200ad5ca85f23b) -  **maps:** Add Complete Mitsubishi Object with coordinates.
- [x] [[`5e782e9`]](https://github.com/yairodriguez/dotbrands/pull/20/commits/5e782e9257844af5409618bf502402c0675d970d) - **comp:** Use Factory to create Mitsubishi logo.
- [x] [[`cba0e36`]](https://github.com/yairodriguez/dotbrands/pull/20/commits/cba0e36b6616e191f4d3bf08bf7deb4642fd4e18) - **style:** Add the correct Mitsubishi Logo styles.

---

### Approvals

- [x] Final approval @yairodriguez