### PR TITLE
0.10.0/DesignPlayboyLogo

### DIFF
--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -6,6 +6,7 @@ import MASTERCARD_COORDINATES from './maps/mastercard';
 import MCDONALDS_COORDINATES from './maps/mcdonalds';
 import MICROSOFT_COORDINATES from './maps/microsoft';
 import MITSUBISHI_COORDINATES from './maps/mitsubishi';
+import PLAYBOY_COORDINATES from './maps/playboy';
 
 export default {
   apple: {
@@ -39,5 +40,9 @@ export default {
   mitsubishi: {
     id: 'mitsubishi',
     coordinates: MITSUBISHI_COORDINATES,
+  },
+  playboy: {
+    id: 'playboy',
+    coordinates: PLAYBOY_COORDINATES,
   },
 };

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -10,4 +10,5 @@ const MasterCard = Factory.create(CONFIG.mastercard);
 const McDonalds = Factory.create(CONFIG.mcdonalds);
 const Microsoft = Factory.create(CONFIG.microsoft);
 const Mitsubishi = Factory.create(CONFIG.mitsubishi);
+const Playboy = Factory.create(CONFIG.playboy);
 /* eslint-enable no-unused-vars */

--- a/app/scripts/maps/playboy.js
+++ b/app/scripts/maps/playboy.js
@@ -1,0 +1,2417 @@
+export default [
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  }, // 1
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 2
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 3
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 4
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 5
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 6
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 7
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 8
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 9
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 10
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  }, // 11
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  }, // 12
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  }, // 13
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 14
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 15
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 16
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 17
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 18
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 19
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 20
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 21
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 22
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 23
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 24
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 25
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 26
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 27
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 28
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 29
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 30
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 31
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 32
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 33
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 34
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 35
+];

--- a/app/styles/components/_playboy.scss
+++ b/app/styles/components/_playboy.scss
@@ -1,0 +1,11 @@
+@charset 'utf-8';
+
+[id='playboy'] {
+  width: calc(6px * 23);
+
+  .point {
+    &.active {
+      background-color: black(0.95);
+    }
+  }
+}

--- a/app/styles/index.scss
+++ b/app/styles/index.scss
@@ -17,3 +17,4 @@
 @import './components/mcdonalds';
 @import './components/microsoft';
 @import './components/mitsubishi';
+@import './components/playboy';

--- a/tests/spec/config.playboy.spec.js
+++ b/tests/spec/config.playboy.spec.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import CONFIG from '../../app/scripts/config';
+
+describe('Playboy Configuration :: Object', () => {
+  it('should have any keys of playboy', () => {
+    expect(CONFIG).to.have.any.keys('playboy');
+  });
+
+  it('should Playboy have an id property', () => {
+    expect(CONFIG.playboy).to.have.property('id');
+  });
+
+  it('should Playboy have a coordinates property', () => {
+    expect(CONFIG.playboy).to.have.property('coordinates');
+  });
+
+  it('should id property be a string', () => {
+    expect(CONFIG.playboy.id).to.be.a('string');
+  });
+
+  it('should coordinates property be an instace of Array', () => {
+    expect(CONFIG.playboy.coordinates).to.be.an('Array');
+  });
+
+  it('should have all id, coordinates keys', () => {
+    expect(CONFIG.playboy).to.contain.all.keys('id', 'coordinates');
+  });
+});

--- a/tests/spec/playboy.map.spec.js
+++ b/tests/spec/playboy.map.spec.js
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import coordinates from '../../app/scripts/maps/playboy';
+
+describe('Coordinates :: Playboy', () => {
+  it('should be an instance of Array', () => {
+    expect(coordinates).to.be.an.instanceof(Array);
+  });
+
+  it('should have any keys of colour', () => {
+    expect(coordinates[0]).to.have.any.keys('colour');
+  });
+
+  it('should exists', () => {
+    expect(coordinates).to.exist; // eslint-disable-line no-unused-expressions
+  });
+
+  it('should be OK', () => {
+    expect(coordinates).to.be.ok; // eslint-disable-line no-unused-expressions
+  });
+
+  it('should be not null', () => {
+    expect(coordinates).to.not.be.a('null');
+  });
+
+  it('should not be empty', () => {
+    expect(coordinates).to.not.be.an('empty');
+  });
+
+  it('should not be undefined', () => {
+    expect(coordinates).to.not.be.an('undefined');
+  });
+
+  it('should have a colour property', () => {
+    expect(coordinates[0]).to.have.property('colour');
+  });
+
+  it('should colour property be a boolean', () => {
+    expect(coordinates[0].colour).to.be.a('boolean');
+  });
+
+  it('should have the correct length', () => {
+    expect(coordinates).to.have.lengthOf(coordinates.length);
+  });
+});


### PR DESCRIPTION
Add Playboy Logo Component in dots.

---

### Issues Addressed

- [x] [#10 – Design Playboy Logo](https://github.com/yairodriguez/dotbrands/issues/10)

All issues in projects: [dotbrands](https://github.com/yairodriguez/dotbrands/issues)

---

### Release Checklist

- [x] [[`6c5c00a`]](https://github.com/yairodriguez/dotbrands/commit/6c5c00ae286874a196c4191cd0e7269df9a73c2f) -  **maps:** Add Complete Playboy Object with coordinates.
- [x] [[`21a74cd`]](https://github.com/yairodriguez/dotbrands/commit/21a74cd97d36bccb8aeb90d65014a5df22910a1b) - **comp:** Use Factory to create Playboy logo.
- [x] [[`873e550`]](https://github.com/yairodriguez/dotbrands/commit/873e5505b99b98e06b5d1da80baddad44324f1d8) - **style:** Add the correct Playboy Logo styles.

---

### Approvals

- [x] Final approval @yairodriguez