### PR TITLE
0.11.0/DesignNikeLogo

### DIFF
--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -7,6 +7,7 @@ import MCDONALDS_COORDINATES from './maps/mcdonalds';
 import MICROSOFT_COORDINATES from './maps/microsoft';
 import MITSUBISHI_COORDINATES from './maps/mitsubishi';
 import PLAYBOY_COORDINATES from './maps/playboy';
+import NIKE_COORDINATES from './maps/nike';
 
 export default {
   apple: {
@@ -40,6 +41,10 @@ export default {
   mitsubishi: {
     id: 'mitsubishi',
     coordinates: MITSUBISHI_COORDINATES,
+  },
+  nike: {
+    id: 'nike',
+    coordinates: NIKE_COORDINATES,
   },
   playboy: {
     id: 'playboy',

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -10,5 +10,6 @@ const MasterCard = Factory.create(CONFIG.mastercard);
 const McDonalds = Factory.create(CONFIG.mcdonalds);
 const Microsoft = Factory.create(CONFIG.microsoft);
 const Mitsubishi = Factory.create(CONFIG.mitsubishi);
+const Nike = Factory.create(CONFIG.nike);
 const Playboy = Factory.create(CONFIG.playboy);
 /* eslint-enable no-unused-vars */

--- a/app/scripts/maps/nike.js
+++ b/app/scripts/maps/nike.js
@@ -1,0 +1,2399 @@
+export default [
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  }, // 1
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 2
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 3
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 4
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 5
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 6
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 7
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 8
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 9
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 10
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 11
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 12
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 13
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 14
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 15
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 16
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: true,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  },
+  {
+    colour: false,
+  }, // 17
+];

--- a/app/styles/components/_nike.scss
+++ b/app/styles/components/_nike.scss
@@ -1,0 +1,11 @@
+@charset 'utf-8';
+
+[id='nike'] {
+  width: calc(6px * 47);
+
+  .point {
+    &.active {
+      background-color: white(0.95);
+    }
+  }
+}

--- a/app/styles/components/_section.scss
+++ b/app/styles/components/_section.scss
@@ -4,7 +4,8 @@
   height: 100vh;
 
   &--apple,
-  &--mastercard {
+  &--mastercard,
+  &--nike {
     background-color: black(0.95);
   }
 

--- a/app/styles/index.scss
+++ b/app/styles/index.scss
@@ -18,3 +18,4 @@
 @import './components/microsoft';
 @import './components/mitsubishi';
 @import './components/playboy';
+@import './components/nike';

--- a/tests/spec/config.nike.spec.js
+++ b/tests/spec/config.nike.spec.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import CONFIG from '../../app/scripts/config';
+
+describe('Nike Configuration :: Object', () => {
+  it('should have any keys of nike', () => {
+    expect(CONFIG).to.have.any.keys('nike');
+  });
+
+  it('should Nike have an id property', () => {
+    expect(CONFIG.nike).to.have.property('id');
+  });
+
+  it('should Nike have a coordinates property', () => {
+    expect(CONFIG.nike).to.have.property('coordinates');
+  });
+
+  it('should id property be a string', () => {
+    expect(CONFIG.nike.id).to.be.a('string');
+  });
+
+  it('should coordinates property be an instace of Array', () => {
+    expect(CONFIG.nike.coordinates).to.be.an('Array');
+  });
+
+  it('should have all id, coordinates keys', () => {
+    expect(CONFIG.nike).to.contain.all.keys('id', 'coordinates');
+  });
+});

--- a/tests/spec/nike.map.spec.js
+++ b/tests/spec/nike.map.spec.js
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import coordinates from '../../app/scripts/maps/nike';
+
+describe('Coordinates :: Nike', () => {
+  it('should be an instance of Array', () => {
+    expect(coordinates).to.be.an.instanceof(Array);
+  });
+
+  it('should have any keys of colour', () => {
+    expect(coordinates[0]).to.have.any.keys('colour');
+  });
+
+  it('should exists', () => {
+    expect(coordinates).to.exist; // eslint-disable-line no-unused-expressions
+  });
+
+  it('should be OK', () => {
+    expect(coordinates).to.be.ok; // eslint-disable-line no-unused-expressions
+  });
+
+  it('should be not null', () => {
+    expect(coordinates).to.not.be.a('null');
+  });
+
+  it('should not be empty', () => {
+    expect(coordinates).to.not.be.an('empty');
+  });
+
+  it('should not be undefined', () => {
+    expect(coordinates).to.not.be.an('undefined');
+  });
+
+  it('should have a colour property', () => {
+    expect(coordinates[0]).to.have.property('colour');
+  });
+
+  it('should colour property be a boolean', () => {
+    expect(coordinates[0].colour).to.be.a('boolean');
+  });
+
+  it('should have the correct length', () => {
+    expect(coordinates).to.have.lengthOf(coordinates.length);
+  });
+});


### PR DESCRIPTION
Add Nike Logo Component in dots.

---

### Issues Addressed

- [x] [#11 – Design Nike Logo](https://github.com/yairodriguez/dotbrands/issues/11)

All issues in projects: [dotbrands](https://github.com/yairodriguez/dotbrands/issues)

---

### Release Checklist

- [x] [[`9418f88`]](https://github.com/yairodriguez/dotbrands/commit/9418f8838407242ee8aa364d59fb2d8f417a707f) -  **maps:** Add Complete Nike Object with coordinates.
- [x] [[`dfdf73a`]](https://github.com/yairodriguez/dotbrands/commit/dfdf73a9bcadd78e510dc28aad2f75d36fa71831) - **comp:** Use Factory to create Nike logo.
- [x] [[`4fb8ec7`]](https://github.com/yairodriguez/dotbrands/commit/4fb8ec7bcd58543549c55989f7e805e9028c7b61) - **style:** Add the correct Nike Logo styles.

---

### Approvals

- [x] Final approval @yairodriguez